### PR TITLE
Version 1.2: Add write() and optional pin labeling

### DIFF
--- a/Encoder/encoder.py
+++ b/Encoder/encoder.py
@@ -1,7 +1,9 @@
 """
 Encoder library for Raspberry Pi for measuring quadrature encoded signals.
 created by Mivallion <mivallion@gmail.com>
-Version 1.0 - 01 april 2020 - inital release
+Version 1.0 - 01 April 2020 - initial release - @mivallion
+Version 1.1 - 15 May   2020 - fixed module import - @mivallion
+Version 1.2 - 30 April 2024 - Added minor features - @CAP1Sup
 """
 
 import RPi.GPIO as GPIO
@@ -9,13 +11,14 @@ import RPi.GPIO as GPIO
 class Encoder(object):
     """
     Encoder class allows to work with rotary encoder
-    which connected via two pin A and B.
+    which connected via two pins: A and B. Pins are labelled
+    in BCM mode by default, but mode can be specified
     Works only on interrupts because all RPi pins allow that.
     This library is a simple port of the Arduino Encoder library
-    (https://github.com/PaulStoffregen/Encoder) 
+    (https://github.com/PaulStoffregen/Encoder)
     """
-    def __init__(self, A, B):
-        GPIO.setmode(GPIO.BCM)
+    def __init__(self, A, B, mode=GPIO.BCM):
+        GPIO.setmode(mode)
         GPIO.setup(A, GPIO.IN)
         GPIO.setup(B, GPIO.IN)
         self.A = A
@@ -34,7 +37,7 @@ class Encoder(object):
     It updates the current position based on previous and current states
     of the rotary encoder.
     """
-    def __update(self, channel):
+    def __update(self):
         state = self.state & 3
         if GPIO.input(self.A):
             state |= 4
@@ -52,9 +55,17 @@ class Encoder(object):
         elif state == 6 or state == 9:
             self.pos -= 2
 
-
     """
     read() simply returns the current position of the rotary encoder.
     """
     def read(self):
         return self.pos
+
+    """
+    write() sets the position to a specified (integer) value
+    """
+    def write(self, value: int):
+        try:
+            self.pos = int(value)
+        except ValueError:
+            raise ValueError("Position must be an integer")

--- a/Encoder/encoder.py
+++ b/Encoder/encoder.py
@@ -36,8 +36,12 @@ class Encoder(object):
     update() calling every time when value on A or B pins changes.
     It updates the current position based on previous and current states
     of the rotary encoder.
+
+    Channel is an optional parameter that is used by some GPIO libraries
+    to specify which channel triggered the event. It is not used in this
+    library, but it is still required in the function definition.
     """
-    def __update(self):
+    def __update(self, channel=None):
         state = self.state & 3
         if GPIO.input(self.A):
             state |= 4

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="Encoder",
-    version="1.1",
+    version="1.2",
     author="Viktor Sevastyanov",
     author_email="mivallion@example.com",
     description="Encoder library for Raspberry Pi for measuring quadrature encoded signals.",


### PR DESCRIPTION
- Added option to specify optional GPIO mode on init. Defaults to the original `GPIO.BCM` for backwards compatibility
- Removed unnecessary  `channel` variable in `__update()` function
- Added `write()` method, which is a part of the Arduino Encoder library